### PR TITLE
Incorrect partition is returned in 'f5_pool_member_availability' collector when the pool is in the Common partition #135

### DIFF
--- a/collectors/collectors.py
+++ b/collectors/collectors.py
@@ -873,6 +873,7 @@ def f5_get_pool_member_availability(username,
                         pool = name[-1].strip()
                     else:
                         pool = line.split()[-1].strip()
+                        partition = 'Common'
 
                     # df_dict[device][pool] = dict()
                     counter = pos+1


### PR DESCRIPTION
closes #135 