### PR TITLE
Update .env_example

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -42,6 +42,7 @@ nxos_devices_password=''
 # F5 LTM VARIABLES
 f5_ltm_username=''
 f5_ltm_password=''
+F5_TELEMETRY_OFF=True
 
 # INFOBLOX VARIABLES
 infoblox_url=''


### PR DESCRIPTION
F5 collectors won't run on updated Ansible lib.

PLAY [F5 Execute Read-only Command] ********************************************

TASK [run "show net arp | grep -v "\\-\\-\\-\\-\|Net::Arp"" on remote devices] *** fatal: [f5llb01 -> localhost]: FAILED! => {"changed": false, "msg": "argument 'no_f5_teem' is of type <class 'NoneType'> found in 'provider'. and we were unable to convert to bool: <class 'NoneType'> cannot be converted to a bool"}

PLAY RECAP *********************************************************************
f5llb01                    : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

$ ansible --version
ansible [core 2.15.3]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/sysadmin/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/sysadmin/source/add-netbox-updaters/.venv/lib/python3.11/site-packages/ansible
  ansible collection location = /home/sysadmin/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/sysadmin/source/add-netbox-updaters/.venv/bin/ansible
  python version = 3.11.2 (main, May 30 2023, 17:45:26) [GCC 12.2.0] (/home/sysadmin/source/add-netbox-updaters/.venv/bin/python3)
  jinja version = 3.1.2
  libyaml = True