### PR TITLE
Fix for Issue #447

### DIFF
--- a/netmanage/parsers/palo_alto_parsers.py
+++ b/netmanage/parsers/palo_alto_parsers.py
@@ -93,6 +93,8 @@ def parse_arp_table(response: dict, nm_path: str) -> pd.DataFrame:
         if not output['response']['result'].get('error'):
             if output['response']['result'].get('entries'):
                 arp_table = output['response']['result']['entries']['entry']
+                if isinstance(arp_table, dict):
+                    arp_table = [arp_table]
                 for item in arp_table:
                     df_data['device'].append(device)
                     for key, value in item.items():

--- a/test/test_palo_alto_collectors.py
+++ b/test/test_palo_alto_collectors.py
@@ -2,10 +2,12 @@
 
 import os
 import sys
+from dotenv import load_dotenv
 
 # Change to the Net-Manage repository so imports will work
-nm_path = os.environ.get('NM_PATH')
-os.chdir(f'{nm_path}/test')
+load_dotenv()
+netmanage_path = os.environ['netmanage_path']
+os.chdir(f'{netmanage_path}/test')
 sys.path.append('..')
 from netmanage.collectors import palo_alto_collectors  # noqa
 
@@ -13,7 +15,7 @@ from netmanage.collectors import palo_alto_collectors  # noqa
 def test_run_adhoc_command(username,
                            password,
                            host_group,
-                           nm_path,
+                           netmanage_path,
                            private_data_dir):
     # Test running an XML command.
     cmd = '<show><system><info></info></system></show>'
@@ -21,7 +23,7 @@ def test_run_adhoc_command(username,
     response = palo_alto_collectors.run_adhoc_command(username,
                                                       password,
                                                       host_group,
-                                                      nm_path,
+                                                      netmanage_path,
                                                       private_data_dir,
                                                       cmd,
                                                       cmd_is_xml)
@@ -34,7 +36,7 @@ def test_run_adhoc_command(username,
     response = palo_alto_collectors.run_adhoc_command(username,
                                                       password,
                                                       host_group,
-                                                      nm_path,
+                                                      netmanage_path,
                                                       private_data_dir,
                                                       cmd,
                                                       cmd_is_xml)
@@ -45,13 +47,13 @@ def test_run_adhoc_command(username,
 def test_get_all_interfaces(username,
                             password,
                             host_group,
-                            nm_path,
+                            netmanage_path,
                             private_data_dir):
     # Test getting all logical interfaces.
     df_all = palo_alto_collectors.get_all_interfaces(username,
                                                      password,
                                                      host_group,
-                                                     nm_path,
+                                                     netmanage_path,
                                                      private_data_dir)
     expected = ['device',
                 'name',
@@ -64,21 +66,19 @@ def test_get_all_interfaces(username,
                 'ip',
                 'id',
                 'addr']
-    assert df_all.columns.to_list() == expected
-
+    assert set(df_all.columns.to_list()) == set(expected)
 
 def test_get_arp_table(username,
                        password,
                        host_group,
-                       nm_path,
-                       private_data_dir,
-                       interface=str()):
+                       netmanage_path,
+                       private_data_dir):
 
     # Test getting the ARP table for all interfaces.
     df_arp = palo_alto_collectors.get_arp_table(username,
                                                 password,
                                                 host_group,
-                                                nm_path,
+                                                netmanage_path,
                                                 private_data_dir)
     expected = ['device',
                 'status',
@@ -88,29 +88,29 @@ def test_get_arp_table(username,
                 'interface',
                 'port',
                 'vendor']
-    assert df_arp.columns.to_list() == expected
+    assert set(df_arp.columns.to_list()) == set(expected)
 
     # Test getting the ARP table for a single interface.
     df_arp = palo_alto_collectors.get_arp_table(username,
                                                 password,
                                                 host_group,
-                                                nm_path,
+                                                netmanage_path,
                                                 private_data_dir,
                                                 interface='management')
     expected = ['device', 'interface', 'ip', 'mac', 'status', 'vendor']
-    assert df_arp.columns.to_list() == expected
+    assert set(df_arp.columns.to_list()) == set(expected)
 
 
 def test_get_logical_interfaces(username,
                                 password,
                                 host_group,
-                                nm_path,
+                                netmanage_path,
                                 private_data_dir):
     # Test getting all logical interfaces.
     df_logical = palo_alto_collectors.get_logical_interfaces(username,
                                                              password,
                                                              host_group,
-                                                             nm_path,
+                                                             netmanage_path,
                                                              private_data_dir)
     expected = ['device',
                 'name',
@@ -123,19 +123,19 @@ def test_get_logical_interfaces(username,
                 'ip',
                 'id',
                 'addr']
-    assert df_logical.columns.to_list() == expected
+    assert set(df_logical.columns.to_list()) == set(expected)
 
 
 def test_get_physical_interfaces(username,
                                  password,
                                  host_group,
-                                 nm_path,
+                                 netmanage_path,
                                  private_data_dir):
     # Test getting all physical interfaces.
     df_phys = palo_alto_collectors.get_physical_interfaces(username,
                                                            password,
                                                            host_group,
-                                                           nm_path,
+                                                           netmanage_path,
                                                            private_data_dir)
     expected = ['device',
                 'name',
@@ -147,45 +147,44 @@ def test_get_physical_interfaces(username,
                 'mode',
                 'speed',
                 'id']
-    assert df_phys.columns.to_list() == expected
+    assert set(df_phys.columns.to_list()) == set(expected)
 
 
 def main():
-    username = os.environ.get('USERNAME')
-    password = os.environ.get('PASSWORD')
-    host_group = os.environ.get('PALO_ALTO_HOST_GROUP')
-    nm_path = os.environ.get('NM_PATH')
-    private_data_dir = os.environ.get('PRIVATE_DATA_DIR')
+    username = os.environ.get('palo_alto_username')
+    password = os.environ.get('palo_alto_password')
+    host_group = os.environ.get('palo_host_group')
+    private_data_dir = os.environ.get('private_data_directory')
 
     # Execute tests
     test_run_adhoc_command(username,
                            password,
                            host_group,
-                           nm_path,
+                           netmanage_path,
                            private_data_dir)
 
     test_get_all_interfaces(username,
                             password,
                             host_group,
-                            nm_path,
+                            netmanage_path,
                             private_data_dir)
 
     test_get_arp_table(username,
                        password,
                        host_group,
-                       nm_path,
+                       netmanage_path,
                        private_data_dir)
 
     test_get_logical_interfaces(username,
                                 password,
                                 host_group,
-                                nm_path,
+                                netmanage_path,
                                 private_data_dir)
 
     test_get_physical_interfaces(username,
                                  password,
                                  host_group,
-                                 nm_path,
+                                 netmanage_path,
                                  private_data_dir)
 
 

--- a/test/test_palo_alto_collectors.py
+++ b/test/test_palo_alto_collectors.py
@@ -153,6 +153,7 @@ def main():
     username = os.environ.get('palo_alto_username')
     password = os.environ.get('palo_alto_password')
     host_group = os.environ.get('palo_host_group')
+    netmanage_path = os.environ.get('netmanage_path')
     private_data_dir = os.environ.get('private_data_directory')
 
     # Execute tests

--- a/test/test_palo_alto_collectors.py
+++ b/test/test_palo_alto_collectors.py
@@ -6,8 +6,6 @@ from dotenv import load_dotenv
 
 # Change to the Net-Manage repository so imports will work
 load_dotenv()
-netmanage_path = os.environ['netmanage_path']
-os.chdir(f'{netmanage_path}/test')
 sys.path.append('..')
 from netmanage.collectors import palo_alto_collectors  # noqa
 

--- a/test/test_palo_alto_collectors.py
+++ b/test/test_palo_alto_collectors.py
@@ -68,6 +68,7 @@ def test_get_all_interfaces(username,
                 'addr']
     assert set(df_all.columns.to_list()) == set(expected)
 
+
 def test_get_arp_table(username,
                        password,
                        host_group,


### PR DESCRIPTION
'test_palo_alto_collectors'.py has been updated.

During testing, an issue was discovered and fixed in the 'palo_alto_parsers.py'. Getting an ARP table with a single entry only returns a "dict". We were expecting a list of dictionaries, added a check to wrap a single dictionary in a list to ensure the data format is as expected.